### PR TITLE
🏗 根据 provider 而不是 serverURL 上传文件、支持直传 COS 

### DIFF
--- a/file_tokens.go
+++ b/file_tokens.go
@@ -48,6 +48,7 @@ type fileTokens struct {
 	Token     string `json:"token"`
 	MimeType  string `json:"mime_type"`
 	Key       string
+	Size      int64
 }
 
 func getFileTokens(name string, mime string, size int64, opts *Options) (*fileTokens, error) {
@@ -67,7 +68,7 @@ func getFileTokens(name string, mime string, size int64, opts *Options) (*fileTo
 		return nil, err
 	}
 
-	url := opts.serverURL() + "/1.1/fileTokens"
+	url := opts.APIServer + "/1.1/fileTokens"
 	request, err := http.NewRequest("POST", url, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
@@ -93,6 +94,7 @@ func getFileTokens(name string, mime string, size int64, opts *Options) (*fileTo
 	if err != nil {
 		return nil, err
 	}
-	result.Key = key // key is not in Server response
+	result.Key = key
+	result.Size = size
 	return result, err
 }

--- a/file_tokens_test.go
+++ b/file_tokens_test.go
@@ -19,8 +19,9 @@ func TestGetFileKey(t *testing.T) {
 
 func TestGetFileTokens(t *testing.T) {
 	_, err := getFileTokens("what", "text/plain", 12345, &Options{
-		AppID:  testAppID,
-		AppKey: testAppKey,
+		AppID:     testAppID,
+		AppKey:    testAppKey,
+		APIServer: testAPIServer,
 	})
 	if err != nil {
 		t.Error(err)

--- a/types.go
+++ b/types.go
@@ -38,12 +38,5 @@ func (err Error) Error() string {
 type Options struct {
 	AppID     string
 	AppKey    string
-	ServerURL string
-}
-
-func (opts *Options) serverURL() string {
-	if opts.ServerURL != "" {
-		return opts.ServerURL
-	}
-	return "https://api.leancloud.cn"
+	APIServer string
 }

--- a/upload_test.go
+++ b/upload_test.go
@@ -6,15 +6,17 @@ import (
 )
 
 const (
-	testAppID  = "pgk9e8orv8l9coak1rjht1avt2f4o9kptb0au0by5vbk9upb"
-	testAppKey = "hi4jsm62kok2qz2w2qphzryo564rzsrucl2czb0hn6ogwwnd"
+	testAppID     = "pgk9e8orv8l9coak1rjht1avt2f4o9kptb0au0by5vbk9upb"
+	testAppKey    = "hi4jsm62kok2qz2w2qphzryo564rzsrucl2czb0hn6ogwwnd"
+	testAPIServer = "https://pgk9e8or.api.lncld.net"
 )
 
 func TestUpload(t *testing.T) {
 	reader := bytes.NewReader([]byte("foobarbaz"))
 	opts := &Options{
-		AppID:  testAppID,
-		AppKey: testAppKey,
+		AppID:     testAppID,
+		AppKey:    testAppKey,
+		APIServer: testAPIServer,
 	}
 	file, err := Upload("xxxooo.txt", "text/plain", reader, opts)
 	if err != nil {


### PR DESCRIPTION
https://github.com/leancloud/lean-cli/pull/388

- （不兼容改动）为了和 app router 2 保持相同的命名，Options 上的 ServerURL 更名 APIServer，同时不再设置默认值
-  先查询 `/1.1/fileTokens`，根据 provider 决定如何上传文件
- 支持直传 COS，删除了 uploadViaLeanCloud